### PR TITLE
[FEAT] Add issue templates for common report/requests.

### DIFF
--- a/.github/ISSUE_TEMPLATE/a_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/a_bug_report.yaml
@@ -1,0 +1,47 @@
+name: Bug Report
+description: Report a problem with the cookiecutter template or the generated project.
+title: '[BUG] '
+labels: [bug]
+body:
+-   type: textarea
+    id: description
+    attributes:
+        label: Description
+        description: Describe the bug clearly and concisely.
+        placeholder: What happened?
+    validations:
+        required: true
+
+-   type: textarea
+    id: reproduce
+    attributes:
+        label: Steps to Reproduce
+        description: Provide all steps, including Cookiecutter prompts.
+        placeholder: |
+            1.
+            2.
+            3.
+    validations:
+        required: true
+
+-   type: textarea
+    id: expected
+    attributes:
+        label: Expected Behavior
+        description: Describe what you expected to happen.
+    validations:
+        required: true
+
+-   type: textarea
+    id: actual
+    attributes:
+        label: Actual Behavior / Logs
+        description: Include error messages, stack traces, or relevant output.
+        render: shell
+
+-   type: input
+    id: environment
+    attributes:
+        label: Environment
+        description: Python version, OS, Cookiecutter version.
+        placeholder: Python 3.12.1, Ubuntu 22.04, Cookiecutter 2.3

--- a/.github/ISSUE_TEMPLATE/b_feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/b_feature_request.yaml
@@ -1,0 +1,39 @@
+name: Feature Request
+description: Suggest an improvement for the Cookiecutter template.
+title: "[Feature] "
+labels: [enhancement]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the feature you propose.
+      placeholder: What should be added or improved?
+    validations:
+      required: true
+
+  - type: textarea
+    id: benefits
+    attributes:
+      label: Rationale
+      description: Why is this feature valuable? How will users benefit?
+    validations:
+      required: true
+
+  - type: textarea
+    id: design
+    attributes:
+      label: Proposed Design
+      description: Describe how the feature could be implemented. Include template variables, folder layout changes, etc.
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Backward Compatibility
+      description: Could this change break existing generated projects?
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: Are there other solutions or approaches?

--- a/.github/ISSUE_TEMPLATE/c_cookiecutter_request.yaml
+++ b/.github/ISSUE_TEMPLATE/c_cookiecutter_request.yaml
@@ -1,0 +1,36 @@
+name: Cookiecutter Option Request
+description: Propose a new Cookiecutter variable or configuration option.
+title: "[Option] "
+labels: [enhancement, cookiecutter]
+body:
+  - type: input
+    id: option_name
+    attributes:
+      label: Option Name
+      placeholder: e.g., enable_fastapi
+    validations:
+      required: true
+
+  - type: textarea
+    id: purpose
+    attributes:
+      label: Purpose
+      description: Why should this option exist?
+
+  - type: textarea
+    id: default
+    attributes:
+      label: Default Value
+      placeholder: "true / false / string"
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact on Template
+      description: What directories, files, or hooks would be affected?
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Suggested Implementation
+      description: Optional but helpful.

--- a/.github/ISSUE_TEMPLATE/d_documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/d_documentation.yaml
@@ -1,0 +1,28 @@
+name: Documentation Improvement
+description: Suggest updates to the README or the generated project docs.
+title: "[Docs] "
+labels: [documentation]
+body:
+  - type: textarea
+    id: scope
+    attributes:
+      label: Topic
+      description: What documentation needs improvement?
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is unclear, inaccurate, or missing?
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Improvement
+      description: How should the documentation be improved?
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Add links or examples if applicable.

--- a/.github/ISSUE_TEMPLATE/e_ux_feddback.yaml
+++ b/.github/ISSUE_TEMPLATE/e_ux_feddback.yaml
@@ -1,0 +1,28 @@
+name: Template UX Feedback
+description: Provide feedback on usability and user experience of the template.
+title: "[UX] "
+labels: [feedback]
+body:
+  - type: textarea
+    id: experience
+    attributes:
+      label: User Experience
+      description: Describe your experience generating a project.
+
+  - type: textarea
+    id: prompts
+    attributes:
+      label: Cookiecutter Prompts
+      description: Were the prompts intuitive and clear?
+
+  - type: textarea
+    id: pain_points
+    attributes:
+      label: Pain Points
+      description: What felt confusing, unnecessary, or complicated?
+
+  - type: textarea
+    id: suggestions
+    attributes:
+      label: Suggestions
+      description: How can we improve the template experience?


### PR DESCRIPTION
This pull request adds several new GitHub issue templates to help users report bugs, request features, suggest new Cookiecutter options, propose documentation improvements, and provide UX feedback. These templates are designed to streamline issue reporting and ensure all necessary information is collected for each type of request.

**New issue templates added:**

*Bug and Feature Reporting*
- Added a bug report template (`a_bug_report.yaml`) to standardize how users report problems with the template or generated projects.
- Added a feature request template (`b_feature_request.yaml`) to guide users in suggesting improvements for the template.

*Cookiecutter Options and Documentation*
- Introduced a template for requesting new Cookiecutter variables or configuration options (`c_cookiecutter_request.yaml`).
- Added a documentation improvement template (`d_documentation.yaml`) for suggesting updates to the README or generated docs.

*User Experience Feedback*
- Created a template for collecting user experience and usability feedback on the template (`e_ux_feddback.yaml`).